### PR TITLE
<add>ボランティア側自治体選択画面

### DIFF
--- a/app/controllers/local_government/registrations_controller.rb
+++ b/app/controllers/local_government/registrations_controller.rb
@@ -10,7 +10,7 @@ class LocalGovernment::RegistrationsController < Devise::RegistrationsController
   protected
 
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name,:email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name,:email,:phone_number])
   end
 
 end

--- a/app/controllers/local_government/sessions_controller.rb
+++ b/app/controllers/local_government/sessions_controller.rb
@@ -12,6 +12,6 @@ class LocalGovernment::SessionsController < Devise::SessionsController
   protected
 
   def configure_sign_in_params
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:email,:name])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:name])
   end
 end

--- a/app/controllers/volunteer/local_governments_controller.rb
+++ b/app/controllers/volunteer/local_governments_controller.rb
@@ -1,7 +1,9 @@
 class Volunteer::LocalGovernmentsController < ApplicationController
   def index
+    @local_governments = LocalGovernment.all
   end
 
   def show
+    @local_government = LocalGovernment.find(params[:id])
   end
 end

--- a/app/views/local_government/homes/top.html.erb
+++ b/app/views/local_government/homes/top.html.erb
@@ -1,2 +1,4 @@
 <h1>LocalGovernment::Homes#top</h1>
 <p>Find me in app/views/local_government/homes/top.html.erb</p>
+
+<%= link_to "ログアウト", destroy_local_government_session_path, method: :delete %>

--- a/app/views/local_government/registrations/new.html.erb
+++ b/app/views/local_government/registrations/new.html.erb
@@ -7,7 +7,8 @@
 
   <div class="row my-5">
 　  <div class="mx-auto">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= form_with model: @local_government, url: registration_path(resource_name) do |f| %>
+
       <%= render "local_government/shared/error_messages", resource: resource %>
 
       <div class="field mt-4">
@@ -16,6 +17,10 @@
 
       <div class="field mt-4">
         <%= f.email_field :email, :placeholder => "メールアドレス", size: "40" %>
+      </div>
+
+      <div class="field mt-4">
+        <%= f.text_field :phone_number, :placeholder => "電話番号", size: "40" %>
       </div>
 
       <div class="field mt-4">
@@ -34,11 +39,11 @@
       </div>
     </div>
   </div>
+  <% end %>
+
   <div class="row my-4">
     <div class="mx-auto">
       <%= render "local_government/shared/links" %>
     </div>
   </div>
 </div>
-
-  <% end %>

--- a/app/views/local_government/sessions/new.html.erb
+++ b/app/views/local_government/sessions/new.html.erb
@@ -6,7 +6,8 @@
   </div>
   <div class="row my-5">
 　  <div class="mx-auto">
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <%= form_with model: @local_government, url: session_path(resource_name) do |f| %>
+
       <div class="field mt-4">
         <%= f.text_field :name, :placeholder => "自治体名", size: "40" %>
       </div>
@@ -22,10 +23,11 @@
         </div>
     </div>
   </div>
+  <% end %>
+
   <div class="row my-4">
     <div class="mx-auto">
       <%= render "local_government/shared/links" %>
     </div>
    </div>
 </div>
-<% end %>

--- a/app/views/volunteer/local_governments/index.html.erb
+++ b/app/views/volunteer/local_governments/index.html.erb
@@ -1,5 +1,27 @@
-<h1>Volunteer::LocalGovernments#index</h1>
-<p>Find me in app/views/volunteer/local_governments/index.html.erb</p>
+<div class="container">
+  <%= link_to "ログアウト", destroy_volunteer_session_path, method: :delete %>
+  <div class="row my-5">
+    <div class="mx-auto">
+      <h1><strong>自治体選択</strong></h1>
+    </div>
+  </div>
+  <div class="row">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th class="text-center">自治体名</th>
+              <th colspan="1"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @local_governments.each do |local_government| %>
+            <tr>
+              <td class="text-center"><%= local_government.name %></td>
+              <td class="text-center"><%= link_to "提供数一覧", volunteer_local_government_path(local_government.id) %></td>
+            </tr>
+            <% end %>
+          </tbody>
+        </table>
 
-自治体選択ページ
-<%= link_to "ログアウト", destroy_volunteer_session_path, method: :delete %>
+  </div>
+</div>

--- a/app/views/volunteer/local_governments/show.html.erb
+++ b/app/views/volunteer/local_governments/show.html.erb
@@ -1,2 +1,4 @@
 <h1>Volunteer::LocalGovernments#show</h1>
 <p>Find me in app/views/volunteer/local_governments/show.html.erb</p>
+
+<%= link_to "自治体選択に戻る", volunteer_local_governments_path %>


### PR DESCRIPTION
本来のボランティア側自治体選択画面以外にも諸々不手際あった箇所を修正しました。
沢山追記あり申し訳ないです確認お願い致します！
・自治体ログイン不具合修正しました（endの位置、form_for→form_with）
・自治体在庫一覧ページにログアウトボタン追記しました。
・自治体新規登録項目にphone_number追記しました（既に新規登録している方はphone_numebrを手打ちで入れるか一度データベースをリセットして再度新規登録お願いします。）
・ログインコントローラーのkeyをnameのみにしました。